### PR TITLE
Corregido el build para los PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ before_script:
 script:
   # Get proper branch name based on http://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
   - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
+  - export BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   # All variables ready - run the test script
   - bash api-spec_validation_test.sh

--- a/api-spec_validation_test.sh
+++ b/api-spec_validation_test.sh
@@ -37,7 +37,7 @@ testOpenApiSpecValidity() {
     validationUrl="http://online.swagger.io/validator/debug?url=$specUrl"
 
     echo "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -"
-    echo "Validating ENV Variables: TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
+    echo "Validating ENV Variables: TRAVIS_BRANCH=$TRAVIS_BRANCH, BRANCH=$BRANCH"
     echo "OpenAPI Specification File=$validationUrl"
     echo "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -"    
 


### PR DESCRIPTION
Viendo que el #1 no compilaba, me fijé que el código para encontrar la rama en `.travis.yml` estaba incorrecto. Lo actualicé según [estas instrucciones](https://github.com/travis-ci/travis-ci/issues/6652).