### PR TITLE
Modificación a get de comunas par aingresar parametro d busqueda por …

### DIFF
--- a/api-users.yml
+++ b/api-users.yml
@@ -786,6 +786,10 @@ definitions:
         description: El rut sin puntos, guión, ni dígito verificador
         minimum: 1
         maximum: 50000000
+      dv:
+        type: string
+        description: digito verificador
+        maxLength: 1
       status:
         type: string
         enum:

--- a/api-users.yml
+++ b/api-users.yml
@@ -703,6 +703,12 @@ paths:
       summary: Retorna la lista de todas las comunas
       tags: 
         - parámetros
+      parameters:
+        - name: "type"
+          in: "query"
+          description: "id de region para busqueda"
+          required: false
+          type: "integer"
       responses:
         '200':
           description: OK

--- a/api-users.yml
+++ b/api-users.yml
@@ -704,7 +704,7 @@ paths:
       tags: 
         - parámetros
       parameters:
-        - name: "type"
+        - name: "region"
           in: "query"
           description: "id de region para busqueda"
           required: false


### PR DESCRIPTION
agregue un parámetro de búsqueda opcional en el GET de comunas para filtrar por región, también agregue el dígito verificador al modelo del rut, ya que ese necesario validar ese dato, de otro modo se podría ingresar cualquier numero en el campo rut sin validar que efectivamente es un rut valido..